### PR TITLE
Full package bump - supporting the test SDK for VS2019

### DIFF
--- a/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
+++ b/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
@@ -14,7 +14,7 @@
     <Description>eShopWorld common test stack</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/eShopWorld/tests-core</PackageProjectUrl>
-    <Copyright>Copyright eShopWorld 2017</Copyright>
+    <Copyright>Copyright eShopWorld 2019</Copyright>
     <PackageTags>Test, Unit Test, xUnit, Moq, FluentAssertions</PackageTags>
     <AssemblyName>Eshopworld.Tests.Core</AssemblyName>
     <RootNamespace>Eshopworld.Tests.Core</RootNamespace>

--- a/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
+++ b/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
@@ -4,13 +4,15 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
 
+    <Version>1.1.0</Version>
+    <PackageReleaseNotes>Bumped all test dependencies to support latest VS2019 test SDKs.</PackageReleaseNotes>
+
     <PackageId>Eshopworld.Tests.Core</PackageId>
-    <Version>1.0.5</Version>
     <Authors>David Rodrigues, Oisin Haken</Authors>
     <Company>eShopWorld</Company>
     <Product>Eshopworld.Tests.Core</Product>
     <Description>eShopWorld common test stack</Description>
-    <PackageLicenseUrl>https://github.com/eShopWorld/tests-core/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/eShopWorld/tests-core</PackageProjectUrl>
     <Copyright>Copyright eShopWorld 2017</Copyright>
     <PackageTags>Test, Unit Test, xUnit, Moq, FluentAssertions</PackageTags>
@@ -22,10 +24,10 @@
 
   <ItemGroup>
     <PackageReference Include="Eshopworld.Tests.Core.Analyzers" Version="1.0.5" />
-    <PackageReference Include="FluentAssertions" Version="5.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Eshopworld.Tests.Core.Tests/Eshopworld.Tests.Core.Tests.csproj
+++ b/src/Tests/Eshopworld.Tests.Core.Tests/Eshopworld.Tests.Core.Tests.csproj
@@ -7,8 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumped all packages to latest.
Mainly interested in the VS2019 test SDK to avoid possible issues for VS2019 users.