### PR TITLE
update Validator Extensions

### DIFF
--- a/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
+++ b/src/Eshopworld.Tests.Core/Eshopworld.Tests.Core.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>true</IsPackable>
 
-    <Version>2.0.9</Version>
-    <PackageReleaseNotes>Add IValidator Extensions</PackageReleaseNotes>
+    <Version>2.0.10</Version>
+    <PackageReleaseNotes>Update builder to support that FluentValidation moved throwAsync from extension method to abstract validator </PackageReleaseNotes>
     <PackageIcon>icon.png</PackageIcon>
     <PackageId>Eshopworld.Tests.Core</PackageId>
     <Authors>David Rodrigues, Oisin Haken</Authors>

--- a/src/Eshopworld.Tests.Core/ValidatorExtensions.cs
+++ b/src/Eshopworld.Tests.Core/ValidatorExtensions.cs
@@ -15,20 +15,14 @@ namespace Eshopworld.Tests.Core
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="mock"></param>
-        /// <param name="errorMessage">When an error is specified then validation will fail</param>
-        /// <param name="propertyName">Used only when <paramref name="errorMessage"/> is specified.
-        /// When null a random value is assigned to the property name validation error </param>
+        /// <param name="errorMessage">error message for the exception</param>
         /// <returns></returns>
-        public static Mock<IValidator<T>> MockValidateAsync<T> (this Mock<IValidator<T>> mock, string errorMessage = null, string propertyName =null)
+        public static Mock<IValidator<T>> MockValidateAsync<T> (this Mock<IValidator<T>> mock, string errorMessage = null)
         {
-            var result = new ValidationResult();
-            if (!string.IsNullOrEmpty(errorMessage))
-                result.Errors.Add(new ValidationFailure(propertyName ?? Lorem.GetWord(), errorMessage));
-
             mock
                 .Setup (validator =>
-                    validator.ValidateAsync (It.IsAny<IValidationContext> (), It.IsAny<CancellationToken> ()))
-                .ReturnsAsync (result)
+                    validator.ValidateAsync (It.IsAny<IValidationContext> () ,It.IsAny<CancellationToken> ()))
+                .ThrowsAsync (new ValidationException (errorMessage))
                 .Verifiable ();
 
             return mock;


### PR DESCRIPTION
## What
There is a change on FluentValidation where `ThrowAsync` method does not throw the exception from the extension method anymore but from the Abstract Validator. As such we need to update our extension method for test